### PR TITLE
fix for React 18 strict mode

### DIFF
--- a/examples/js/03-react.tsx
+++ b/examples/js/03-react.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom/client';
 import Elevio from '../../src/react';
 
 type State = {
@@ -80,7 +80,11 @@ class App extends React.Component<{}, State> {
 function render() {
   const target = document.getElementById('root');
   if (!target) throw new Error('Cant find target div');
-  ReactDOM.render(<App />, target);
+  ReactDOM.createRoot(target).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
 }
 
 render();

--- a/package.json
+++ b/package.json
@@ -13,25 +13,25 @@
     "@skypack/package-check": "^0.2.2",
     "@types/ejs": "^3.0.6",
     "@types/express": "^4.17.12",
-    "@types/prop-types": "^15.7.3",
-    "@types/react": "^17.0.37",
-    "@types/react-dom": "^17.0.11",
-    "@types/webpack": "^5.28.0",
-    "@types/webpack-dev-middleware": "^5.0.0",
+    "@types/prop-types": "^15.7.5",
+    "@types/react": "^18.2.6",
+    "@types/react-dom": "^18.2.4",
+    "@types/webpack": "^5.28.1",
+    "@types/webpack-dev-middleware": "^5.0.2",
     "cypress": "^3.8.3",
     "ejs": "^3.1.6",
     "express": "^4.17.2",
     "html-webpack-plugin": "^5.5.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "start-server-and-test": "^1.12.5",
-    "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
-    "typescript": "^4.3.5",
-    "webpack": "^5.41.1",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-middleware": "^5.0.0",
-    "webpack-dev-server": "^4.7.1"
+    "ts-loader": "^9.4.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4",
+    "webpack": "^5.82.0",
+    "webpack-cli": "^5.1.0",
+    "webpack-dev-middleware": "^6.1.0",
+    "webpack-dev-server": "^4.15.0"
   },
   "scripts": {
     "clean": "rm -f ./lib/*; rm -f ./esm/*",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "prop-types": "^15.8.0"
+    "prop-types": "^15.8.1"
   },
   "files": [
     "lib/*",

--- a/src/client.ts
+++ b/src/client.ts
@@ -75,7 +75,7 @@ const ElevioExports = {
   /**
    * Disabled Elevio completely, if it was enabled.
    */
-  disable: noop as typeof disable,
+  disable: () => {},
 
   /**
    * Enable Elevio if it was disabled.

--- a/src/elevio.ts
+++ b/src/elevio.ts
@@ -37,8 +37,7 @@ export type OnEventTypes = {
   'search:query': (results: {
     query: string;
     results: Array<{
-      // TODO: should be included
-      // category_id: string;
+      category_id: string;
       id: string;
       title: string;
     }>;
@@ -52,8 +51,7 @@ export type OnEventTypes = {
    */
   'search:article:clicked': (result: {
     articleId: number;
-    // TODO: should be included
-    // categoryId: string;
+    categoryId: string;
     source: string;
   }) => void;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "declaration": true,
     "esModuleInterop": true,
     "removeComments": false,
-    "jsx": "react"
+    "jsx": "react",
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "lib"],
   "files": ["src/index.ts"]


### PR DESCRIPTION
Fixes #13 

With React 18's Strict mode in development components are mounted, unmounted and then remounted to make sure that all effects cancel themselves correctly.

Because this happened before Elevio had initialised the `componentWillUnmount` method was calling the noop function which triggered a warning.

This PR replaces the noop function for disable to not have that warning.